### PR TITLE
fix set avatar fo other use than current logged in

### DIFF
--- a/rocketchat_API/APISections/base.py
+++ b/rocketchat_API/APISections/base.py
@@ -78,12 +78,17 @@ class RocketChatBase:
             timeout=self.timeout,
         )
 
-    def call_api_post(self, method, files=None, use_json=True, **kwargs):
+    def call_api_post(self, method, files=None, use_json=None, **kwargs):
         reduced_args = self.__reduce_kwargs(kwargs)
         # Since pass is a reserved word in Python it has to be injected on the request dict
         # Some methods use pass (users.register) and others password (users.create)
         if "password" in reduced_args and method != "users.create":
             reduced_args["pass"] = reduced_args["password"]
+        if use_json is None:
+            # see https://requests.readthedocs.io/en/master/user/quickstart/#more-complicated-post-requests
+            # > The json parameter is ignored if either data or files is passed.
+            # If files are sent, json should not be used 
+            use_json = files is None
         if use_json:
             return self.req.post(
                 self.server_url + self.API_path + method,


### PR DESCRIPTION
`users_set_avatar` should call `users_set_avatar` with `use_json` set to `True` when using a file and not an URL. If not, requests ignore given json (data, with the userId param) as explained in the doc: https://requests.readthedocs.io/en/master/user/quickstart/#more-complicated-post-requests  
> Note, the json parameter is ignored if either data or files is passed.

But I prefer a more generic way by editing the `call_api_post` method to avoid a default `use_json=True` param and have a default value depending on the `files` param. If it sets, then default value for `use_json` will now be init to `False`.

With this change, all calls to  `call_api_post` with `files` set could now remove the `use_json=True` kwarg.